### PR TITLE
Allow default requests parameters like proxy to be defined in extra options field of a Airflow HTTP Connection

### DIFF
--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -112,8 +112,15 @@ class HttpHook(BaseHook):
             elif self._auth_type:
                 session.auth = self.auth_type()
             if conn.extra:
+                extra_options = conn.extra_dejson
+                extra_options.pop("timeout", None)
+                extra_options.pop("allow_redirects", None)
+                extra_options.pop("proxies", None)
+                extra_options.pop("verify", None)
+                extra_options.pop("cert", None)
+
                 try:
-                    session.headers.update(conn.extra_dejson)
+                    session.headers.update(extra_options)
                 except TypeError:
                     self.log.warning("Connection to %s has invalid extra field.", conn.host)
         if headers:

--- a/airflow/providers/http/hooks/http.py
+++ b/airflow/providers/http/hooks/http.py
@@ -26,6 +26,7 @@ import tenacity
 from aiohttp import ClientResponseError
 from asgiref.sync import sync_to_async
 from requests.auth import HTTPBasicAuth
+from requests.models import DEFAULT_REDIRECT_LIMIT
 from requests_toolbelt.adapters.socket_options import TCPKeepAliveAdapter
 
 from airflow.exceptions import AirflowException
@@ -113,11 +114,11 @@ class HttpHook(BaseHook):
                 session.auth = self.auth_type()
             if conn.extra:
                 extra_options = conn.extra_dejson
-                extra_options.pop("timeout", None)
-                extra_options.pop("allow_redirects", None)
-                extra_options.pop("proxies", None)
-                extra_options.pop("verify", None)
-                extra_options.pop("cert", None)
+                session.proxies = extra_options.pop("proxies", {})
+                session.stream = extra_options.pop("stream", False)
+                session.verify = extra_options.pop("verify", True)
+                session.cert = extra_options.pop("cert", None)
+                session.max_redirects = extra_options.pop("max_redirects", DEFAULT_REDIRECT_LIMIT)
 
                 try:
                     session.headers.update(extra_options)


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: 36732
related: 36732

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
